### PR TITLE
Add dwm_loadavg to display the average system load

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ A modular statusbar for dwm
   - [dwm_ccurse](#dwm_ccurse)
   - [dwm_transmission](#dwm_transmission)
   - [dwm_backlight](#dwm_backlight)
+  - [dwm_loadavg](#dwm_loadavg)
 - [Installation](#installation)
 - [Reccomendations](#reccomendations)
 - [Usage](#usage)
@@ -140,6 +141,11 @@ Displays the current backlight level with xbacklight
 [☀ 80]
 ```
 Dependencies: ```xbacklight```
+### dwm_loadavg
+Displays the average system load
+```
+[⏱ 0.14 0.17 0.18]
+```
 ## Installation
 1. Clone and enter the repository:
 ```

--- a/bar-functions/dwm_loadavg.sh
+++ b/bar-functions/dwm_loadavg.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+# A dwm_bar function to read the average system load
+# Alvar Penning <post@0x21.biz>
+# GNU GPLv3
+
+dwm_loadavg () {
+    # LOAD_FIELDS specifies the load average values to be displayed. Values
+    # within 1-3 are allowed, passed as a range (-) or comma-separated.
+    # - 1: load average within the last minute
+    # - 2: load average within the last five minutes
+    # - 3: load average within the last fifteen minutes
+    LOAD_FIELDS=1,2,3
+
+    LOAD_AVG=$(cut -d " " -f ${LOAD_FIELDS} /proc/loadavg)
+
+    printf "%s" "$SEP1"
+    if [ "$IDENTIFIER" = "unicode" ]; then
+        printf "⏱ %s" "$LOAD_AVG"
+    else
+        printf "AVG %s" "$LOAD_AVG"
+    fi
+    printf "%s\n" "$SEP2"
+}
+
+dwm_loadavg

--- a/dwm_bar.sh
+++ b/dwm_bar.sh
@@ -40,10 +40,11 @@ export SEP2="]"
 . "$DIR/bar-functions/dwm_keyboard.sh"
 . "$DIR/bar-functions/dwm_ccurse.sh"
 . "$DIR/bar-functions/dwm_date.sh"
+. "$DIR/bar-functions/dwm_loadavg.sh"
 
 # Update dwm status bar every second
 while true
 do
-    xsetroot -name "$(dwm_countdown)$(dwm_alarm.sh)$(dwm_transmission)$(dwm_cmus)$(dwm_mpc)$(dwm_spotify)$(dwm_resources)$(dwm_battery)$(dwm_mail)$(dwm_backlight)$(dwm_alsa)$(dwm_pulse)$(dwm_weather)$(dwm_vpn)$(dwm_networkmanager)$(dwm_keyboard)$(dwm_ccurse)$(dwm_date)"
+    xsetroot -name "$(dwm_countdown)$(dwm_alarm.sh)$(dwm_transmission)$(dwm_cmus)$(dwm_mpc)$(dwm_spotify)$(dwm_resources)$(dwm_battery)$(dwm_mail)$(dwm_backlight)$(dwm_alsa)$(dwm_pulse)$(dwm_weather)$(dwm_vpn)$(dwm_networkmanager)$(dwm_keyboard)$(dwm_ccurse)$(dwm_date)$(dwm_loadavg)"
     sleep 1
 done


### PR DESCRIPTION
This PR introduces a new `bar-function` to display the average system load, `dwm_loadavg`.

Feel free to change the Unicode glyph, as I didn't found anything suitable.