### PR TITLE
Adds network information support for connman

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ A modular statusbar for dwm
   - [dwm_ccurse](#dwm_ccurse)
   - [dwm_transmission](#dwm_transmission)
   - [dwm_backlight](#dwm_backlight)
+  - [dwm_connman](#dwm_connman)
 - [Installation](#installation)
 - [Reccomendations](#reccomendations)
 - [Usage](#usage)
@@ -140,6 +141,12 @@ Displays the current backlight level with xbacklight
 [☀ 80]
 ```
 Dependencies: ```xbacklight```
+### dwm_connman
+Shows network information IP, SSID, WLan strength (if connected to WLan) using connman.
+```
+[🌐 192.169.189.12 HomeNetworkName 53%]
+```
+Dependencies: ```connman```
 ## Installation
 1. Clone and enter the repository:
 ```

--- a/bar-functions/dwm_connman.sh
+++ b/bar-functions/dwm_connman.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+
+# A dwm_bar function to show the current network connection/SSID, Wifi Strength, private IP using Connmanctl.
+# procrastimax <heykeroth.dev@gmail.com>
+# GNU GPLv3
+
+# Dependencies: connman
+
+dwm_connman () {
+    printf "%s" "$SEP1"
+    if [ "$IDENTIFIER" = "unicode" ]; then
+        printf "🌐 "
+    else
+        printf "NET "
+    fi
+
+    # get the connmanctl service name
+    # this is a UID starting with 'vpn_', 'wifi_', or 'ethernet_', we dont care for the vpn one
+    # if the servicename string is empty, there is no online connection
+    SERVICENAME=$(connmanctl services | grep -E "^\*AO|^\*O" | grep -Eo 'wifi_.*|ethernet_.*')
+
+    if [ ! "$SERVICENAME" ]; then
+        printf "OFFLINE"
+        printf "%s\n" "$SEP2"
+        return
+    else
+        STRENGTH=$(connmanctl services "$SERVICENAME" | sed -n -e 's/Strength =//p' | tr -d ' ')
+        CONNAME=$(connmanctl services "$SERVICENAME" | sed -n -e 's/Name =//p' | tr -d ' ')
+        IP=$(connmanctl services "$SERVICENAME" | grep 'IPv4 =' | awk '{print $5}' | sed -n -e 's/Address=//p' | tr -d ',')
+    fi
+
+    # if STRENGTH is empty, we have a wired connection
+    if [ "$STRENGTH" ]; then
+        printf "%s %s %s%%" "$IP" "$CONNAME" "$STRENGTH"
+    else
+        printf "%s %s" "$IP" "$CONNAME"
+    fi
+
+    printf "%s\n" "$SEP2"
+}
+
+dwm_connman

--- a/dwm_bar.sh
+++ b/dwm_bar.sh
@@ -40,10 +40,11 @@ export SEP2="]"
 . "$DIR/bar-functions/dwm_keyboard.sh"
 . "$DIR/bar-functions/dwm_ccurse.sh"
 . "$DIR/bar-functions/dwm_date.sh"
+. "$DIR/bar-functions/dwm_connman.sh"
 
 # Update dwm status bar every second
 while true
 do
-    xsetroot -name "$(dwm_countdown)$(dwm_alarm.sh)$(dwm_transmission)$(dwm_cmus)$(dwm_mpc)$(dwm_spotify)$(dwm_resources)$(dwm_battery)$(dwm_mail)$(dwm_backlight)$(dwm_alsa)$(dwm_pulse)$(dwm_weather)$(dwm_vpn)$(dwm_networkmanager)$(dwm_keyboard)$(dwm_ccurse)$(dwm_date)"
+    xsetroot -name "$(dwm_connman)$(dwm_countdown)$(dwm_alarm.sh)$(dwm_transmission)$(dwm_cmus)$(dwm_mpc)$(dwm_spotify)$(dwm_resources)$(dwm_battery)$(dwm_mail)$(dwm_backlight)$(dwm_alsa)$(dwm_pulse)$(dwm_weather)$(dwm_vpn)$(dwm_networkmanager)$(dwm_keyboard)$(dwm_ccurse)$(dwm_date)"
     sleep 1
 done


### PR DESCRIPTION
Connman is a lightweight network manager.
With this patch basic network information like SSID, WLan signal strength and IP can be provided to the dwm-bar.