### PR TITLE
Simplify the volume query

### DIFF
--- a/bar-functions/dwm_pulse.sh
+++ b/bar-functions/dwm_pulse.sh
@@ -7,7 +7,7 @@
 # Dependencies: pamixer
 
 dwm_pulse () {
-    VOL=$(pamixer --get-volume-human | tr -d '%')
+    VOL=$(pamixer --get-volume)
     
     printf "%s" "$SEP1"
     if [ "$IDENTIFIER" = "unicode" ]; then


### PR DESCRIPTION
it is possible to use `--get-volume` to avoid having to strip the percent sign