### PR TITLE
. in 17,74 so that identifier as non-unicode can see the sign.

### DIFF
--- a/bar-functions/dwm_weather.sh
+++ b/bar-functions/dwm_weather.sh
@@ -14,7 +14,7 @@ dwm_weather() {
     if [ "$IDENTIFIER" = "unicode" ]; then
         printf "%s" "$(curl -s wttr.in/$LOCATION?format=1)"
     else
-        printf "WEA %s" "$(curl -s wttr.in/$LOCATION?format=1 | grep -o "[0-9].*")"
+        printf "WEA %s" "$(curl -s wttr.in/$LOCATION?format=1 | grep -o ".[0-9].*")"
     fi
     printf "%s\n" "$SEP2"
 }


### PR DESCRIPTION
In dwm_weather.sh I added a "." before the "[" at position (17,74) so that a user whose identifier is not "unicode" can see the sign of the temperature.

This is useful if you are on the Northern Hemisphere to check whether it is +5 or -5 outside without having to open the window to check it out.