### PR TITLE
Adds Fedora Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,13 @@ $ cd dwm-bar
 $ sudo pacman -S $(dep/arch.txt)
 ```
 
-> :warning: Currently, only arch linux supports this feature. Dependency Lists for other Distributions are to be aded in future.
+  * For Fedora Linux
+
+```
+$ sudo dnf install $(dep/fedora.txt)
+```
+
+> :warning: There are no dnf packages for [spotyfyd](https://github.com/Spotifyd/spotifyd), [pamixer](https://github.com/cdemoulins/pamixer) and [cmus](https://github.com/cmus/cmus). If you want to utilise these packages, please install them manually as shown in the corresponding gihub repos.
 
 3. Make the script executable
 ```

--- a/dep/fedora.txt
+++ b/dep/fedora.txt
@@ -1,0 +1,14 @@
+alsa-utils
+setxkbmap
+mpc
+wpa_supplicant
+NetworkManager
+NetworkManager-openvpn
+calcurse
+transmission-remote-gtk
+xbacklight
+connman
+connman-devel
+curl
+playerctl
+playerctl-devel


### PR DESCRIPTION

This commit introduces fedora 34 Support by adding all necessary
dependencies to a dep/fedora.txt file. The only issue is that not all 
dependencies can be installed through a package manager so 
some dependencies will have to be installed manually by either
compiling them from source,  by including custom `dnf` repositories 
or by installing custom rpm packages.

![image](https://user-images.githubusercontent.com/45271583/119394947-d50b2a00-bca0-11eb-95b6-9e9e64ebf504.png)
As it can be seen from the screenshot above, all dependencies from dep/fedora.txt are found.