### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ $ sudo pacman -S $(dep/arch.txt)
 $ sudo dnf install $(dep/fedora.txt)
 ```
 
-> :warning: There are no dnf packages for [spotyfyd](https://github.com/Spotifyd/spotifyd), [pamixer](https://github.com/cdemoulins/pamixer) and [cmus](https://github.com/cmus/cmus). If you want to utilise these packages, please install them manually as shown in the corresponding gihub repos.
+> :warning: There are no dnf packages for [spotifyd](https://github.com/Spotifyd/spotifyd), [pamixer](https://github.com/cdemoulins/pamixer) and [cmus](https://github.com/cmus/cmus). If you want to utilise these packages, please install them manually as shown in the corresponding gihub repos.
 
 3. Make the script executable
 ```


### PR DESCRIPTION
spotifyd was incorrectly spelled as spotyfyd