### PR TITLE
Add xsetroot to void dependencies

### DIFF
--- a/dep/void.txt
+++ b/dep/void.txt
@@ -13,3 +13,4 @@ curl
 pamixer
 spotifyd
 playerctl
+xsetroot


### PR DESCRIPTION
Added xsetroot to the void dependencies, since it's not included in the base void install  