### PR TITLE
Make Shell commands copy paste friendly

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,14 +38,14 @@ A modular statusbar for dwm
 ## Installation
 1. Clone and enter the repository:
 ```
-$ git clone https://github.com/joestandring/dwm-bar
-$ cd dwm-bar
+git clone https://github.com/joestandring/dwm-bar
+cd dwm-bar
 ```
 2. (Optional) Install Dependencies from ```dep/YourDisto.txt```. This will install dependencies for ALL functions so consider excluding ones you do not plan to use. These can be found at the top of each bar function.
 ```
-$ sudo xbps-install -S $(cat dep/void.txt) # Void
-$ sudo pacman -S $(cat dep/arch.txt)       # Arch
-$ sudo dnf install $(cat dep/fedora.txt)   # Fedora
+sudo xbps-install -S $(cat dep/void.txt) # Void
+sudo pacman -S $(cat dep/arch.txt)       # Arch
+sudo dnf install $(cat dep/fedora.txt)   # Fedora
 ```
 > :warning: There are no dnf packages for [spotifyd](https://github.com/Spotifyd/spotifyd), [pamixer](https://github.com/cdemoulins/pamixer) and [cmus](https://github.com/cmus/cmus). If you want to utilise these packages, please install them manually as shown in the corresponding gihub repos.
 3. (Optional) If you plan to use unicode identifiers, you should install a font which includes these ([Nerd Fonts](https://github.com/ryanoasis/nerd-fonts), [siji](https://github.com/stark/siji))


### PR DESCRIPTION
With the great copy paste feature, Github allows for easier copying of markdown code blocks. This makes it more copy paste friendly. All commands are also valid if done as root, thus the "not root user"-semantic isn't even needed.