### PR TITLE
Fix CPU displaying in dwm_resources.sh

### DIFF
--- a/bar-functions/dwm_resources.sh
+++ b/bar-functions/dwm_resources.sh
@@ -14,7 +14,7 @@ dwm_resources () {
 	MEMUSED=$(echo $free_output | awk '{print $3}')
 	MEMTOT=$(echo $free_output | awk '{print $2}')
 	# CPU temperature
-	CPU=$(top -bn1 | grep Cpu | awk '{print $2}')%
+	CPU=$(top -bn1 | grep -m 1 CPU | awk '{print $2}')%
 	#CPU=$(sysctl -n hw.sensors.cpu0.temp0 | cut -d. -f1)
 	# Used and total storage in /home (rounded to 1024B)
 	STOUSED=$(echo $df_output | awk '{print $3}')


### PR DESCRIPTION
Before fixing it displayed pid of grep instead of used CPU

The problem was in using grep by Cpu when required line could be found by CPU
I also added -m 1 flag because there may be other lines contained CPU
for exemple line with grep process